### PR TITLE
Setting the frame strata to DIALOG

### DIFF
--- a/MythicPlusLoot.lua
+++ b/MythicPlusLoot.lua
@@ -979,6 +979,7 @@ function initFrames()
 		frame:SetPoint("CENTER");
 		frame:SetWidth(sizex);
 		frame:SetHeight(sizey);
+		frame:SetFrameStrata("DIALOG");
 
 		local tex = frame:CreateTexture(nil, "BACKGROUND");
 		tex:SetAllPoints();


### PR DESCRIPTION
Currently, the frame gets behind any other frame with a MEDIUM strata (default for many addons; Dominos, TMW, .. etc)

Before
![image](https://user-images.githubusercontent.com/20221435/159120237-08721c2f-9540-4e07-a663-34af21ef33cb.png)

After
![image](https://user-images.githubusercontent.com/20221435/159120246-ec0aaea2-beff-425d-9c85-de2a59904ad1.png)
